### PR TITLE
Update logger to use LoggerAwareTrait

### DIFF
--- a/src/SwarmProcess.php
+++ b/src/SwarmProcess.php
@@ -7,7 +7,6 @@
 
 namespace Afrihost\SwarmProcess;
 
-use Psr\Log\LoggerInterface;
 use Symfony\Component\Process\Process;
 
 class SwarmProcess extends SwarmProcessBase
@@ -25,16 +24,10 @@ class SwarmProcess extends SwarmProcessBase
     private $runningProcessKeyTracker = 0;
 
     /**
-     * @return LoggerInterface
-     */
-    public function getLogger()
-    {
-        return $this->logger;
-    }
-
-    /**
      * Runs all the processes, not going over the maxRunStackSize, and continuing until all processes in the processingStack has run their course.
+     *
      * @param callable $moreWorkToAddCallable
+     * @param callable $shouldContinueRunningCallable
      */
     public function run(callable $moreWorkToAddCallable = null, callable $shouldContinueRunningCallable = null)
     {
@@ -64,7 +57,7 @@ class SwarmProcess extends SwarmProcessBase
             $tmpProcess = array_shift($this->queue);
             $tmpProcess->start();
             $this->currentRunningStack[++$this->runningProcessKeyTracker] = $tmpProcess;
-            $this->getLogger()->info('+ Started Process ' . $this->runningProcessKeyTracker . ' [' . $tmpProcess->getCommandLine() . ']');
+            $this->logger->info('+ Started Process ' . $this->runningProcessKeyTracker . ' [' . $tmpProcess->getCommandLine() . ']');
         }
 
         // Loop through the running things to check if they're done:
@@ -75,7 +68,7 @@ class SwarmProcess extends SwarmProcessBase
                     'ExitCode:'.$runningProcess->getExitCode().'('.$runningProcess->getExitCodeText().') '.
                     '[' . count($this->queue) . ' left in queue]';
                 unset($this->currentRunningStack[$runningProcessKey]);
-                $this->getLogger()->info($logMessage);
+                $this->logger->info($logMessage);
             }
         }
 
@@ -135,7 +128,7 @@ class SwarmProcess extends SwarmProcessBase
     {
         $this->queue[] = $process;
 
-        $this->getLogger()->debug('Process pushed on to stack. Stack size: ' . count($this->queue));
+        $this->logger->debug('Process pushed on to stack. Stack size: ' . count($this->queue));
 
         return $this;
     }
@@ -154,7 +147,9 @@ class SwarmProcess extends SwarmProcessBase
      * Set the maximum number of processes that can be run at the same time (concurrently)
      *
      * @param int $maxRunStackSize
+     *
      * @return SwarmProcess
+     * @throws \OutOfBoundsException
      */
     public function setMaxRunStackSize($maxRunStackSize)
     {
@@ -164,7 +159,7 @@ class SwarmProcess extends SwarmProcessBase
 
         $this->maxRunStackSize = $maxRunStackSize;
 
-        $this->getLogger()->debug('$maxRunStackSize changed to ' . $maxRunStackSize);
+        $this->logger->debug('$maxRunStackSize changed to ' . $maxRunStackSize);
 
         return $this;
     }

--- a/src/SwarmProcessBase.php
+++ b/src/SwarmProcessBase.php
@@ -7,27 +7,23 @@
 
 namespace Afrihost\SwarmProcess;
 
+use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 abstract class SwarmProcessBase
 {
-    /** @var LoggerInterface */
-    protected $logger;
+    use LoggerAwareTrait;
 
     /**
      * SwarmProcess constructor.
+     *
      * @param LoggerInterface $logger
      */
     public function __construct(LoggerInterface $logger = null)
     {
-        if (!is_null($logger)) {
-            $this->logger = $logger;
-        } else {
-            $this->logger = new NullLogger();
-        }
+        $this->setLogger($logger ?: new NullLogger());
 
-        $this->getLogger()->debug('__construct(ed) SwarmProcess');
+        $this->logger->debug('__construct(ed) SwarmProcess');
     }
-
 }

--- a/tests/SwarmProcessTest.php
+++ b/tests/SwarmProcessTest.php
@@ -1,7 +1,5 @@
 <?php
 use Afrihost\SwarmProcess\SwarmProcess;
-use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 
 /**
  * User: sarel
@@ -10,15 +8,11 @@ use Psr\Log\NullLogger;
  */
 class SwarmProcessTest extends PHPUnit_Framework_TestCase
 {
-    /** @var LoggerInterface */
-    private $logger;
-
     /** @var SwarmProcess */
     private $swarm;
 
     protected function setUp() {
-        $this->logger = new NullLogger();
-        $this->swarm = new SwarmProcess($this->logger);
+        $this->swarm = new SwarmProcess();
     }
 
     public function testSetMaxRunStack()

--- a/tests/SwarmProcessTestNoSetup.php
+++ b/tests/SwarmProcessTestNoSetup.php
@@ -1,5 +1,6 @@
 <?php
 use Afrihost\SwarmProcess\SwarmProcess;
+use Psr\Log\AbstractLogger;
 use Psr\Log\NullLogger;
 
 /**
@@ -14,17 +15,26 @@ class SwarmProcessTestNoSetup extends PHPUnit_Framework_TestCase
      */
     public function testLoggerGiven()
     {
-        $given = new NullLogger();
+        $given = new TestLogger();
 
         $swarm = new SwarmProcess($given);
 
-        $this->assertTrue($given === $swarm->getLogger(), 'Logger given at construction not the same as class has internally');
+        $this->assertSame($given, \PHPUnit_Framework_Assert::getObjectAttribute($swarm, 'logger'), 'Logger given at construction not the same as class has internally');
     }
 
     public function testLoggerNotGiven()
     {
         $swarm = new SwarmProcess();
 
-        $this->assertInstanceOf('Psr\Log\NullLogger', $swarm->getLogger(), 'Logger expected when none is given, should be the NullLogger');
+        $this->assertInstanceOf('Psr\Log\NullLogger', \PHPUnit_Framework_Assert::getObjectAttribute($swarm, 'logger'), 'Logger expected when none is given, should be the NullLogger');
     }
 }
+
+class TestLogger extends AbstractLogger
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function log($level, $message, array $context = []) {}
+}
+


### PR DESCRIPTION
The class `SwarmProcessBase` used `$this->getLogger()` in the constructor, without the `getLogger` method defined as an abstract (or concrete) function on the class. So it assumes that any class that extends it, will implement the `getLogger` method, without it being part of a contract.

While fixing this, I thought that usage of `LoggerAwareTrait` would be better suited, since it exposes the necessary method to set the logger (as well as overwrite it in the case of setter injection) and removes the unnecessary calls to `getlogger()`
