### PR TITLE
Fix Travis Builds (PHP 5 and HHVM) and Test Minimum Depandancies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,7 @@ matrix:
     - php: 7.2
     - php: hhvm-3.24
   allow_failures:
-    - php: 5.5
-    - php: 5.6
     - php: hhvm-3.24
-    - php: 7.1
-    - php: 7.2
 
 # Cache composer files for faster test times
 cache:
@@ -30,7 +26,6 @@ cache:
     - $HOME/.composer/cache
 
 before_script:
-  - curl -sSfL -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar
   - composer self-update
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,12 @@ matrix:
   fast_finish: true
   include:
     - php: 5.5
+    - php: 5.5
+      env: DEPENDENCIES='low'
     - php: 5.6
     - php: 7.0
+    - php: 7.0
+      env: DEPENDENCIES='low'
     - php: 7.1
     - php: 7.2
     - php: hhvm-3.24
@@ -28,6 +32,9 @@ cache:
 before_script:
   - curl -sSfL -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar
   - composer self-update
-  - composer install --prefer-source --no-interaction --dev
+
+install:
+  - if [ -z "$DEPENDENCIES" ]; then composer install --no-interaction --prefer-dist; fi;
+  - if [ "$DEPENDENCIES" == "low" ]; then composer update --no-interaction  --prefer-dist --prefer-lowest; fi;
  
 script: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "monolog/monolog": "1.*"
   },
   "require-dev": {
-    "phpunit/phpunit": "~6.0",
+    "phpunit/phpunit": "^6|^5",
     "symfony/console": "~3.4",
     "symfony/var-dumper": "~3.4"
   },
@@ -23,5 +23,10 @@
     "psr-4": {
       "Afrihost\\SwarmProcess\\": "src"
     }
+  },
+  "autoload-dev": {
+    "files": [
+      "tests/alias.php"
+    ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "monolog/monolog": "1.*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6|^5",
+    "phpunit/phpunit": "^4|^5|^6",
     "symfony/console": "~3.4",
     "symfony/var-dumper": "~3.4"
   },

--- a/tests/alias.php
+++ b/tests/alias.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * This file allows PHPUnit TestCases for PHPUnit version 6 to be run under PHPUnit version 5 by aliasing the classes
+ * with namespaces to the old ones without to allow tests to be run under PHP 5
+ */
+if (!class_exists('\PHPUnit\Framework\TestCase') && class_exists('\PHPUnit_Framework_TestCase')) {
+    class_alias('\PHPUnit_Framework_TestCase', '\PHPUnit\Framework\TestCase');
+}


### PR DESCRIPTION
This PR Fixes all the TravisCI Builds

*PHPUnit 5* has been added as an optional requirement to support the *PHP 5.6* and *HHVM* build while version 4 has been added for PHP 5.5. All other build continue to use *PHPUnit 6*

Support for the namespace changes in *PHPUnit 6* has been added by aliasing the `TestCase` class without the namespace to the version 6 on with a namespace.

Additional TravisCI builds have been added for *PHP 5.5* and *PHP 7.0* that have composer install the minimum version of packages allowed to ensure that tests pass on the full range of allowed backages 