### PR TITLE
Move tickLoopDelay to the end of the tick loop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ before_script:
   - composer self-update
   - composer require satooshi/php-coveralls
   - composer install
+  - echo 'xdebug.mode = "coverage"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 install:
   - if [ -z "$DEPENDENCIES" ]; then composer install --no-interaction --prefer-dist; fi;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,4 +19,9 @@
             <directory suffix=".php">./src</directory>
         </whitelist>
     </filter>
+    <php>
+        <!-- Temporarily prevent XDEBUG bug - see  https://github.com/xdebug/xdebug/pull/699 -->
+        <const name="XDEBUG_CC_UNUSED"  value=""/>
+        <const name="XDEBUG_CC_DEAD_CODE"  value="-1"/>
+    </php>
 </phpunit>

--- a/src/SwarmProcess.php
+++ b/src/SwarmProcess.php
@@ -41,10 +41,6 @@ class SwarmProcess extends SwarmProcessBase
                 }
             }
 
-            // If configured, slow down the loop slightly to save CPU.
-            if ($this->getConfiguration()->getTickLoopDelayMicroseconds() > 0) {
-                usleep($this->getConfiguration()->getTickLoopDelayMicroseconds());
-            }
         } while ($this->tick() || (is_callable($shouldContinueRunningCallable) ? call_user_func($shouldContinueRunningCallable) : false));
     }
 
@@ -87,6 +83,11 @@ class SwarmProcess extends SwarmProcessBase
         }
 
         $this->tickFillOpenSlots();
+
+        // If configured, slow down the loop slightly to save CPU.
+        if ($this->getConfiguration()->getTickLoopDelayMicroseconds() > 0) {
+            usleep($this->getConfiguration()->getTickLoopDelayMicroseconds());
+        }
 
         return ((count($this->queue) > 0) || count($this->currentRunningStack) > 0);
     }


### PR DESCRIPTION
Hi @sarelvdwalt 

This PR simply moves the `usleep` until after all the work of the tick has been completed.

Prior to this change, the first sleep occurs before to the first call to `tickFillOpenSlots()`. This means that there are no processes running during the first sleep. This is undesirable in cases where only a few iterations of some long-running processes are expected and thus a longer delay is desirable.