### PR TITLE
Make the shouldContinueRunningCallable actually work as a way to interup processing.

### DIFF
--- a/src/SwarmProcess.php
+++ b/src/SwarmProcess.php
@@ -41,7 +41,7 @@ class SwarmProcess extends SwarmProcessBase
                 }
             }
 
-        } while ($this->tick() || (is_callable($shouldContinueRunningCallable) ? call_user_func($shouldContinueRunningCallable) : false));
+        } while ($this->tick() && (is_callable($shouldContinueRunningCallable) ? call_user_func($shouldContinueRunningCallable) : true));
     }
 
     /**

--- a/src/SwarmProcess.php
+++ b/src/SwarmProcess.php
@@ -42,6 +42,19 @@ class SwarmProcess extends SwarmProcessBase
             }
 
         } while ($this->tick() && (is_callable($shouldContinueRunningCallable) ? call_user_func($shouldContinueRunningCallable) : true));
+
+
+        /**
+         * @var  Process $runningProcess
+         */
+        foreach ($this->currentRunningStack as $runningProcessKey => $runningProcess) {
+            if ($runningProcess->isRunning()) {
+                $runningProcess->stop();
+                // do nothing, just log as checkTimeout() internally stops the process
+                $logMessage = '- Killed Process ' . $runningProcessKey . ' from currentRunningStack.';
+                $this->logger->warning($logMessage);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Change the statement that governs the while loop running to actually have the shouldContinueRunningCallable be a way to interrupt the swarm as it's name suggest. 

Also then run a final cleanup on the swarm to kill any leftover processes that are still running instead of orphaning them.