### PR TITLE
Set a sensible default value to tick-loop-delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ $swarmProcess->run();
 The above will run the two processes concurrently. The timeout of both are set to 5 seconds (you can obviously set individual timeouts for all). Therefore the `sleep 9` process will get timed out once the internal `tick()` method is executed, but the `sleep 2` process will run it's course naturally. Invoking the timeout like this on a process will have SwarmProcess pass a warning to the logger passed in. You can use the callback structure explained above to programatically notice this by looking at the exitCode and do something about the timeout.
 
 #### Tick delay
-This feature exists in order to make the internal loop less heavy on the CPU. There are little need to run the loop constantly, as fast as possible. It is in most cases sufficient to check only every 0.1 seconds. For backward compatibility, this is an optional configuration. Here is how it is activated:
+This feature exists in order to make the internal loop less heavy on the CPU. There are little need to run the loop constantly, as fast as possible. It is in most cases sufficient to check only every 0.1 seconds. For backward compatibility, this is an optional configuration. However, a sensibly low value of 0.01 seconds (10000 microseconds) have been set as the default value. Here is how it is activated:
 
 ```php
 $logger = new Logger('swarm_logger');

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -10,7 +10,7 @@ class Configuration
     private $enforceProcessTimeouts = false;
 
     /** @var int $tickLoopDelayMicroseconds */
-    private $tickLoopDelayMicroseconds = 0;
+    private $tickLoopDelayMicroseconds = 10000; // sensibly set to 10000 microseconds to play nice with CPU cycles
 
     /**
      * @return int

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -45,7 +45,7 @@ class ConfigurationTest extends PHPUnit\Framework\TestCase
     public function testSetTickLoopDelayMicroseconds()
     {
         // check default is 0:
-        $this->assertEquals(0, $this->swarmConfig->getTickLoopDelayMicroseconds());
+        $this->assertEquals(10000, $this->swarmConfig->getTickLoopDelayMicroseconds());
 
         // test set and get:
         $this->swarmConfig->setTickLoopDelayMicroseconds(1234);


### PR DESCRIPTION
When the tick loop delay is 0 microseconds, the loop to periodically check whether the process is still running consumes a large amount of a CPU core. Checking so fast is, in most cases, not needed.

After testing, a sensible value of 10 000 microseconds (0.01 seconds) was chosen. This appears to be the lowest sensible value.

The value can still be overwritten to lower than 10 000 or even zero should the need arise, using `setTickLoopDelayMicroseconds()` on the `Configuration` object.